### PR TITLE
Fetch cities only at the start

### DIFF
--- a/CityMapProject/CityMapProject/CityList/CityListView.swift
+++ b/CityMapProject/CityMapProject/CityList/CityListView.swift
@@ -28,7 +28,6 @@ struct CityListView<ViewModel>: View where ViewModel: CityListViewModeling {
                     EmptyView()
                 }
             }
-            .onAppear(perform: viewModel.fetchCities)
             .navigationDestination(for: CityModel.self) { city in
                 //navigate to mapView with city
             }

--- a/CityMapProject/CityMapProject/CityList/CityListViewModel/CityListViewModel.swift
+++ b/CityMapProject/CityMapProject/CityList/CityListViewModel/CityListViewModel.swift
@@ -29,6 +29,7 @@ final class CityListViewModel: CityListViewModeling {
     
     init(repository: CityListRepositoryProtocol = CityListRepository()){
         self.repository = repository
+        self.fetchCities()
     }
     
     func fetchCities() {


### PR DESCRIPTION
## Fix/Fetch cities only at the start
- Remove the fetch method on the onAppear hook 
- Fetch cities at the  viewModel initializer 